### PR TITLE
Download setup script in install

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -110,8 +110,8 @@ echo -e "${success_msg}SUCCESS${fin}"
 headline "Setting up remote host"
 
 echo -en "${action}"
-# Run remote setup script
-ssh -T "${ssh_username}@${hostname}" "sh -s -- '${ssh_public_key}'" < "bin/setup_remote_host.sh"
+# Download and run remote setup script
+curl -fsSL "https://raw.githubusercontent.com/codingjoe/the-box/refs/heads/main/bin/setup_remote_host.sh" | ssh -T "${ssh_username}@${hostname}" "sh -s -- '${ssh_public_key}'"
 echo -en "${fin}"
 echo -e "${success_msg}Remote host setup completed!${fin}"
 echo -en "${action}Creating Docker context for remote host... "


### PR DESCRIPTION
## Why

`bin/install.sh` previously piped a local copy of `bin/setup_remote_host.sh` over SSH. This required the file to already exist in the working tree, which is fragile and breaks when the script is run outside a full checkout.

## What

The install wizard now downloads `setup_remote_host.sh` from the repository's raw GitHub URL and pipes it over SSH, so it no longer depends on a local copy being present.

```bash
curl -fsSL "https://raw.githubusercontent.com/codingjoe/the-box/refs/heads/main/bin/setup_remote_host.sh" | ssh -T "${ssh_username}@${hostname}" "sh -s -- '${ssh_public_key}'"
```

## Notes

- The URL is pinned to the `main` branch of `codingjoe/the-box`.
- `set -euo pipefail` ensures a failed download aborts the pipeline.