### PR TITLE
Fix Docker Compose project name to use ref_name instead of event ref

### DIFF
--- a/actions/backup/action.yml
+++ b/actions/backup/action.yml
@@ -50,7 +50,7 @@ runs:
         cp .env.${{ inputs.environment }} .env
     - name: Capture Postgres backup
       shell: sh
-      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.event.ref || github.ref_name }} exec postgres /usr/bin/pg_dump -Rc -U postgres postgres > backup.dump
+      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.ref_name }} exec postgres /usr/bin/pg_dump -Rc -U postgres postgres > backup.dump
       env:
         DOTENV_PRIVATE_KEY: ${{ inputs.dotenv-private-key }}
     - name: Encrypt backup

--- a/actions/delete/action.yml
+++ b/actions/delete/action.yml
@@ -49,7 +49,7 @@ runs:
         curl -fsSL https://dotenvx.sh | sh
         cp .env.${{ inputs.environment }} .env
     - name: Delete application deployment from the box
-      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.event.ref || github.ref_name }} down --volumes --remove-orphans
+      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.ref_name }} down --volumes --remove-orphans
       shell: sh
       env:
         HOSTNAME: ${{ inputs.hostname }}

--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -49,7 +49,7 @@ runs:
         curl -fsSL https://dotenvx.sh | sh
         cp .env.${{ inputs.environment }} .env
     - name: Deploy application to the box
-      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.event.ref || github.ref_name }} up --detach --quiet-pull
+      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.ref_name }} up --detach --quiet-pull
       shell: sh
       env:
         HOSTNAME: ${{ inputs.hostname }}


### PR DESCRIPTION
## Why

The backup, deploy, and delete GitHub Actions were failing with:

```
invalid project name "relay-refs/heads/main": must consist only of lowercase alphanumeric characters, hyphens, and underscores
```

Docker Compose rejects project names containing slashes, but the actions were passing `github.event.ref` (e.g. `refs/heads/main`) as part of the project name.

## What changed

All three composite actions (`backup`, `deploy`, `delete`) used `${{ github.event.ref || github.ref_name }}` for the `--project-name` flag. Since `github.event.ref` is always truthy (it evaluates to the full ref path like `refs/heads/main`), the `|| github.ref_name` fallback never fired.

Replaced the expression with `${{ github.ref_name }}`, which returns just the short branch/tag name (e.g. `main`) -- no `refs/heads/` prefix, no slashes. This works correctly for `schedule`, `workflow_dispatch`, and `workflow_run` triggers.

The project name now resolves to `the-box-main` instead of `the-box-refs/heads/main`.