### PR TITLE
Use compressed binary format for pg_dump backups

### DIFF
--- a/actions/backup/action.yml
+++ b/actions/backup/action.yml
@@ -50,7 +50,7 @@ runs:
         cp .env.${{ inputs.environment }} .env
     - name: Capture Postgres backup
       shell: sh
-      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.ref_name }} exec postgres /usr/bin/pg_dump -Rc -U postgres postgres > backup.dump
+      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.ref_name }} exec postgres /usr/bin/pg_dump -Fc -U postgres postgres > backup.dump
       env:
         DOTENV_PRIVATE_KEY: ${{ inputs.dotenv-private-key }}
     - name: Encrypt backup

--- a/bin/backup_capture.sh
+++ b/bin/backup_capture.sh
@@ -6,7 +6,7 @@ set -eu
 printf "Backing up PostgreSQL database..."
 mkdir -p ./backups
 FILENAME="./backups/$(date -u +%Y-%m-%dT%H:%M:%SZ).dump"
-until docker compose exec postgres /usr/bin/pg_dump -Rc -U postgres postgres > "$FILENAME"
+until docker compose exec postgres /usr/bin/pg_dump -Fc -U postgres postgres > "$FILENAME"
 do
     printf "."
     sleep 1


### PR DESCRIPTION
Fixes `pg_dump -Rc` -> `pg_dump -Fc` so backups use PostgreSQL's custom (compressed binary) format as intended. The restore script (`pg_restore`) already expects this format.