### PR TITLE
Fix postgres L4 proxy: use postgres protocol matcher

### DIFF
--- a/containers/compose.postgres.yml
+++ b/containers/compose.postgres.yml
@@ -11,14 +11,13 @@ services:
       - app
       - caddy
     labels:
-      - "caddy=pg.${PG_HOST:-localhost}"
+      - "caddy=pg.${HOSTNAME:-localhost}"
       - "caddy.respond=OK"
-      - 'caddy_1.servers.listener_wrappers.0_layer4.@tls-pgsql=tls'
-      - 'caddy_1.servers.listener_wrappers.0_layer4.@tls-pgsql.alpn=postgresql'
-      - 'caddy_1.servers.listener_wrappers.0_layer4.@tls-pgsql.sni=pg.${PG_HOST:-localhost}'
-      - 'caddy_1.servers.listener_wrappers.0_layer4.route=@tls-pgsql'
-      - 'caddy_1.servers.listener_wrappers.0_layer4.route.0_tls.connection_policy.alpn=postgresql'
-      - 'caddy_1.servers.listener_wrappers.0_layer4.route.1_proxy={{upstreams 5432}}'
+      - 'caddy_1.servers.listener_wrappers.0_layer4.@pg_tls.postgres.tls=enabled'
+      - 'caddy_1.servers.listener_wrappers.0_layer4.route_0=@pg_tls'
+      - 'caddy_1.servers.listener_wrappers.0_layer4.route_0.0_postgres_tls='
+      - 'caddy_1.servers.listener_wrappers.0_layer4.route_0.1_tls.connection_policy.alpn=postgresql'
+      - 'caddy_1.servers.listener_wrappers.0_layer4.route_0.2_proxy={{upstreams 5432}}'
       - 'caddy_1.servers.listener_wrappers.1_tls='
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -21,8 +21,6 @@ PostgreSQL is optional. When the postgres service is included in the composition
 psql "postgresql://postgres:${POSTGRES_PASSWORD}@pg.${HOSTNAME}:443/postgres?sslmode=require"
 ```
 
-The proxy accepts both classic `SSLRequest` negotiation and plaintext connections.
-
 Redis is optional. When the redis service is included in the composition, it is exposed through the Caddy reverse proxy on port `443` with TLS termination. Connect from outside the Docker host with:
 
 ```bash


### PR DESCRIPTION
## Why

The merged postgres L4 proxy never worked. `psql` sends a plaintext SSLRequest packet first, not a TLS ClientHello. The `tls` matcher with SNI/ALPN never matched, so connections fell through to the HTTPS handler and were rejected.

## Fix

- Use caddy-l4's `postgres` protocol matcher (`@pg_tls.postgres.tls=enabled`) instead of the `tls` matcher. The postgres matcher understands the PostgreSQL wire protocol and detects SSLRequest.
- Handler chain: `postgres_tls` (responds to SSLRequest) → `tls` (terminates TLS with `alpn=postgresql` connection policy) → `proxy` (forwards to upstream).
- Also fixes `PG_HOST` → `HOSTNAME` (undefined variable) and removes a false "plaintext connections" claim from docs.

## Verified

```bash
psql "postgresql://postgres:postgres@pg.localhost:443/postgres?sslmode=require" -c "SELECT 1"
# → ?column?  /  1  /  (1 row)

redis-cli --tls -h redis.localhost -p 443 --sni redis.localhost -a redis --insecure PING
# → PONG
```