### PR TITLE
Always pull images when deploying

### DIFF
--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -49,7 +49,7 @@ runs:
         curl -fsSL https://dotenvx.sh | sh
         cp .env.${{ inputs.environment }} .env
     - name: Deploy application to the box
-      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.ref_name }} up --detach --quiet-pull
+      run: dotenvx run -- docker compose --file compose.${{ inputs.environment }}.yml --project-name ${{ github.event.repository.name }}-${{ github.ref_name }} up --detach --pull always --quiet-pull
       shell: sh
       env:
         HOSTNAME: ${{ inputs.hostname }}


### PR DESCRIPTION
The deploy action only pulled images when they were missing locally, so a stale image could be reused if the tag already existed on the server. This meant deployments did not reliably pick up the latest published images.

Add `--pull always` to the compose up command in the deploy action so it always pulls the latest images before deploying. This matches the behavior already used in the update action.